### PR TITLE
Pre release v5.3

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Pretty Go Errors",
   "publisher": "CWDev",
   "description": "Make Go diagnostics easier to read in VS Code hovers",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/colinwilliams91/pretty-go-errors",

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Pretty Go Errors",
   "publisher": "CWDev",
   "description": "Make Go diagnostics easier to read in VS Code hovers",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/colinwilliams91/pretty-go-errors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/vscode-extension": {
       "name": "pretty-go-errors",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pretty-go-errors/vscode-formatter": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/vscode-extension": {
       "name": "pretty-go-errors",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pretty-go-errors/vscode-formatter": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pretty-go-errors-mono",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pretty-go-errors-mono",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "workspaces": [
         "packages/*",
         "apps/*"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "test": "npm run test --workspaces --if-present",
     "format": "prettier --write \"**/*.{ts,js,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\"",
+    "bump": "npm --workspace apps/vscode-extension version",
     "package": "npm --workspace apps/vscode-extension run package",
-    "ready": "npm run test && npm run lint && npm run format:check && npm run build && node -e \"console.log('\\x1b[38;2;0;128;128mExtension is ready for publishing! Run npm version <major|minor|patch> && npm run package\\x1b[0m')\""
+    "ready": "npm run test && npm run lint && npm run format:check && npm run build && node -e \"const version = require('./apps/vscode-extension/package.json').version; console.log(`\\x1b[38;2;0;128;128mVersion ${version} is ready to bump and publish! Bump by running npm run bump -- <major|minor|patch> && npm run package\\x1b[0m`)\""
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-go-errors-mono",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/formatter/src/prettifyGoDiagnostic.ts
+++ b/packages/formatter/src/prettifyGoDiagnostic.ts
@@ -45,6 +45,7 @@ export function parseGoDiagnostic(message: string): ParsedDiagnostic {
     parseCannotConvert(rawMessage) ??
     parseUndefined(rawMessage) ??
     parseUnknownField(rawMessage) ??
+    parseMissingFieldOrMethod(rawMessage) ??
     parseMissingModule(rawMessage) ??
     parsePackageStd(rawMessage) ??
     parseNotAType(rawMessage) ??
@@ -228,6 +229,44 @@ function parseUnknownField(message: string): ParsedDiagnostic | null {
     details: [
       { label: "Field", kind: "code", value: field, language: "go" },
       { label: "Struct type", kind: "code", value: targetType, language: "go" },
+    ],
+  };
+}
+
+function parseMissingFieldOrMethod(message: string): ParsedDiagnostic | null {
+  const match = message.match(
+    /^(.+) undefined \(type (.+?) has no field or method (.+?)\)$/
+  );
+  if (!match) {
+    return null;
+  }
+
+  const [, expression, targetType, member] = match;
+  return {
+    family: "missing-field-or-method",
+    title: "Missing field or method",
+    summary:
+      "This type does not define the referenced field or method on the selected value.",
+    rawMessage: message,
+    details: [
+      {
+        label: "Expression",
+        kind: "code",
+        value: expression,
+        language: "go",
+      },
+      {
+        label: "Receiver type",
+        kind: "code",
+        value: targetType,
+        language: "go",
+      },
+      {
+        label: "Missing member",
+        kind: "code",
+        value: member,
+        language: "go",
+      },
     ],
   };
 }

--- a/packages/formatter/src/prettifyGoDiagnostic.ts
+++ b/packages/formatter/src/prettifyGoDiagnostic.ts
@@ -36,12 +36,16 @@ export interface ParsedDiagnostic {
 const CALL_ARGUMENT_COUNT_PATTERN =
   /^(too many arguments in call to|not enough arguments in call to) ([^\n]+)\n\s*have \(([^\n]*)\)\n\s*want \(([^\n]*)\)$/;
 
+const CONVERSION_ARGUMENT_COUNT_PATTERN =
+  /^(missing argument|too many arguments) in conversion to (.+)$/;
+
 export function parseGoDiagnostic(message: string): ParsedDiagnostic {
   const rawMessage = compactLines(message);
 
   return (
     parseCallArgumentCount(rawMessage) ??
     parseCannotUse(rawMessage) ??
+    parseConversionArgumentCount(rawMessage) ??
     parseCannotConvert(rawMessage) ??
     parseUndefined(rawMessage) ??
     parseUnknownField(rawMessage) ??
@@ -169,6 +173,35 @@ function createCannotUseDiagnostic(
     summary: "A value is being used where Go expects a different type.",
     rawMessage,
     details,
+  };
+}
+
+function parseConversionArgumentCount(
+  message: string
+): ParsedDiagnostic | null {
+  const match = message.match(CONVERSION_ARGUMENT_COUNT_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  const [, kind, targetType] = match;
+  return {
+    family: "conversion-arguments",
+    title:
+      kind === "missing argument"
+        ? "Missing conversion argument"
+        : "Too many conversion arguments",
+    summary:
+      "Go conversions must provide exactly one value to convert to the target type.",
+    rawMessage: message,
+    details: [
+      {
+        label: "Target type",
+        kind: "code",
+        value: targetType,
+        language: "go",
+      },
+    ],
   };
 }
 

--- a/packages/formatter/test/formatter.test.ts
+++ b/packages/formatter/test/formatter.test.ts
@@ -46,7 +46,7 @@ describe("parseGoDiagnostic", () => {
 
   it("formats missing field or method diagnostics", () => {
     const parsed = parseGoDiagnostic(
-      'huh.NewGroup(huh.NewMultiSelect[string]().Options(huh.NewOption("copilot", "copilot"), huh.NewOption("claude", "claude"), huh.NewOption("codex", "codex"), huh.NewOption("cursor", "cursor")).Key("Harnesses").Title("Select one or more AI Harnesses to support").Value(&config.harnessSelections)).Skip undefined (type *huh.Group has no field or method Skip)'
+      "config.Theme undefined (type *Config has no field or method Theme)"
     );
 
     expect(parsed.family).toBe("missing-field-or-method");
@@ -55,16 +55,15 @@ describe("parseGoDiagnostic", () => {
       expect.arrayContaining([
         expect.objectContaining({
           label: "Expression",
-          value:
-            'huh.NewGroup(huh.NewMultiSelect[string]().Options(huh.NewOption("copilot", "copilot"), huh.NewOption("claude", "claude"), huh.NewOption("codex", "codex"), huh.NewOption("cursor", "cursor")).Key("Harnesses").Title("Select one or more AI Harnesses to support").Value(&config.harnessSelections)).Skip',
+          value: "config.Theme",
         }),
         expect.objectContaining({
           label: "Receiver type",
-          value: "*huh.Group",
+          value: "*Config",
         }),
         expect.objectContaining({
           label: "Missing member",
-          value: "Skip",
+          value: "Theme",
         }),
       ])
     );

--- a/packages/formatter/test/formatter.test.ts
+++ b/packages/formatter/test/formatter.test.ts
@@ -70,6 +70,23 @@ describe("parseGoDiagnostic", () => {
     );
   });
 
+  it("formats missing conversion argument diagnostics", () => {
+    const parsed = parseGoDiagnostic(
+      "missing argument in conversion to CustomType"
+    );
+
+    expect(parsed.family).toBe("conversion-arguments");
+    expect(parsed.title).toBe("Missing conversion argument");
+    expect(parsed.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Target type",
+          value: "CustomType",
+        }),
+      ])
+    );
+  });
+
   it("falls back for unmatched diagnostics", () => {
     const parsed = parseGoDiagnostic("made up diagnostic");
     expect(parsed.family).toBe("fallback");

--- a/packages/formatter/test/formatter.test.ts
+++ b/packages/formatter/test/formatter.test.ts
@@ -44,6 +44,32 @@ describe("parseGoDiagnostic", () => {
     );
   });
 
+  it("formats missing field or method diagnostics", () => {
+    const parsed = parseGoDiagnostic(
+      'huh.NewGroup(huh.NewMultiSelect[string]().Options(huh.NewOption("copilot", "copilot"), huh.NewOption("claude", "claude"), huh.NewOption("codex", "codex"), huh.NewOption("cursor", "cursor")).Key("Harnesses").Title("Select one or more AI Harnesses to support").Value(&config.harnessSelections)).Skip undefined (type *huh.Group has no field or method Skip)'
+    );
+
+    expect(parsed.family).toBe("missing-field-or-method");
+    expect(parsed.title).toBe("Missing field or method");
+    expect(parsed.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Expression",
+          value:
+            'huh.NewGroup(huh.NewMultiSelect[string]().Options(huh.NewOption("copilot", "copilot"), huh.NewOption("claude", "claude"), huh.NewOption("codex", "codex"), huh.NewOption("cursor", "cursor")).Key("Harnesses").Title("Select one or more AI Harnesses to support").Value(&config.harnessSelections)).Skip',
+        }),
+        expect.objectContaining({
+          label: "Receiver type",
+          value: "*huh.Group",
+        }),
+        expect.objectContaining({
+          label: "Missing member",
+          value: "Skip",
+        }),
+      ])
+    );
+  });
+
   it("falls back for unmatched diagnostics", () => {
     const parsed = parseGoDiagnostic("made up diagnostic");
     expect(parsed.family).toBe("fallback");

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
+// TODO: maybe we format code blocks here? (new line after each chained command, e.g. "." operator) differently in cases where the original message had newlines vs. all on one line?
 export function compactLines(input: string): string {
   return input
     .split(/\r?\n/)

--- a/packages/vscode-formatter/src/prettifyDiagnosticForHover.ts
+++ b/packages/vscode-formatter/src/prettifyDiagnosticForHover.ts
@@ -23,6 +23,7 @@ export function renderParsedDiagnosticForHover(
   diagnostic: Omit<HoverDiagnosticLike, "message">
 ): string {
   const metadata = formatMetadata(diagnostic);
+  // TODO: conditionally format codeblocks (rendered under "Value" header) to have newlines after each chained command, e.g. "." operator
   const sections = parsed.details.map(renderDetail).join("\n\n");
 
   return [

--- a/packages/vscode-formatter/test/vscode-formatter.test.ts
+++ b/packages/vscode-formatter/test/vscode-formatter.test.ts
@@ -42,6 +42,20 @@ describe("prettifyDiagnosticForHover", () => {
     expect(markdown).toContain("```go\nSkip\n```");
   });
 
+  it("renders missing conversion argument diagnostics", () => {
+    const markdown = prettifyDiagnosticForHover({
+      source: "compiler",
+      code: "WrongArgCount",
+      message: "missing argument in conversion to CustomType",
+    });
+
+    expect(markdown).toContain("### Missing conversion argument");
+    expect(markdown).toContain("Source: compiler");
+    expect(markdown).toContain("Code: WrongArgCount");
+    expect(markdown).toContain("**Target type**");
+    expect(markdown).toContain("```go\nCustomType\n```");
+  });
+
   it("falls back cleanly when a partially similar diagnostic does not match a rule", () => {
     const markdown = prettifyDiagnosticForHover({
       message: "cannot use value with an unexpected diagnostic layout",

--- a/packages/vscode-formatter/test/vscode-formatter.test.ts
+++ b/packages/vscode-formatter/test/vscode-formatter.test.ts
@@ -25,6 +25,23 @@ describe("prettifyDiagnosticForHover", () => {
     expect(markdown).toContain("mystery diagnostic");
   });
 
+  it("renders missing field or method diagnostics", () => {
+    const markdown = prettifyDiagnosticForHover({
+      source: "compiler",
+      code: "MissingFieldOrMethod",
+      message:
+        'huh.NewGroup(huh.NewMultiSelect[string]().Options(huh.NewOption("copilot", "copilot"), huh.NewOption("claude", "claude"), huh.NewOption("codex", "codex"), huh.NewOption("cursor", "cursor")).Key("Harnesses").Title("Select one or more AI Harnesses to support").Value(&config.harnessSelections)).Skip undefined (type *huh.Group has no field or method Skip)',
+    });
+
+    expect(markdown).toContain("### Missing field or method");
+    expect(markdown).toContain("Source: compiler");
+    expect(markdown).toContain("Code: MissingFieldOrMethod");
+    expect(markdown).toContain("**Receiver type**");
+    expect(markdown).toContain("```go\n*huh.Group\n```");
+    expect(markdown).toContain("**Missing member**");
+    expect(markdown).toContain("```go\nSkip\n```");
+  });
+
   it("falls back cleanly when a partially similar diagnostic does not match a rule", () => {
     const markdown = prettifyDiagnosticForHover({
       message: "cannot use value with an unexpected diagnostic layout",

--- a/packages/vscode-formatter/test/vscode-formatter.test.ts
+++ b/packages/vscode-formatter/test/vscode-formatter.test.ts
@@ -30,16 +30,16 @@ describe("prettifyDiagnosticForHover", () => {
       source: "compiler",
       code: "MissingFieldOrMethod",
       message:
-        'huh.NewGroup(huh.NewMultiSelect[string]().Options(huh.NewOption("copilot", "copilot"), huh.NewOption("claude", "claude"), huh.NewOption("codex", "codex"), huh.NewOption("cursor", "cursor")).Key("Harnesses").Title("Select one or more AI Harnesses to support").Value(&config.harnessSelections)).Skip undefined (type *huh.Group has no field or method Skip)',
+        "config.Theme undefined (type *Config has no field or method Theme)",
     });
 
     expect(markdown).toContain("### Missing field or method");
     expect(markdown).toContain("Source: compiler");
     expect(markdown).toContain("Code: MissingFieldOrMethod");
     expect(markdown).toContain("**Receiver type**");
-    expect(markdown).toContain("```go\n*huh.Group\n```");
+    expect(markdown).toContain("```go\n*Config\n```");
     expect(markdown).toContain("**Missing member**");
-    expect(markdown).toContain("```go\nSkip\n```");
+    expect(markdown).toContain("```go\nTheme\n```");
   });
 
   it("renders missing conversion argument diagnostics", () => {


### PR DESCRIPTION
- Add support for 2x more diagnostics (see commits)
- Add some todos/pseudo code for code block/fence formatting in render
- Make tests agnostic to 3rd party libraries (more generic)