### PR TITLE
Pre release v5.6 Diagnostic support Missing Comma in Argument List (see desc)

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Pretty Go Errors",
   "publisher": "CWDev",
   "description": "Make Go diagnostics easier to read in VS Code hovers",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/colinwilliams91/pretty-go-errors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/vscode-extension": {
       "name": "pretty-go-errors",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pretty-go-errors/vscode-formatter": "*"

--- a/packages/formatter/src/prettifyGoDiagnostic.ts
+++ b/packages/formatter/src/prettifyGoDiagnostic.ts
@@ -289,7 +289,8 @@ function parseMissingComma(message: string): ParsedDiagnostic | null {
   return {
     family: "missing-comma",
     title: "Missing comma",
-    summary: "Go expected a comma separator here before the syntax could continue.",
+    summary:
+      "Go expected a comma separator here before the syntax could continue.",
     rawMessage: message,
     details: [
       {

--- a/packages/formatter/src/prettifyGoDiagnostic.ts
+++ b/packages/formatter/src/prettifyGoDiagnostic.ts
@@ -49,6 +49,7 @@ export function parseGoDiagnostic(message: string): ParsedDiagnostic {
     parseCannotConvert(rawMessage) ??
     parseNonLocalMethodDefinition(rawMessage) ??
     parseExpectedOperand(rawMessage) ??
+    parseMissingComma(rawMessage) ??
     parseUndefined(rawMessage) ??
     parseUnknownField(rawMessage) ??
     parseMissingFieldOrMethod(rawMessage) ??
@@ -273,6 +274,33 @@ function parseExpectedOperand(message: string): ParsedDiagnostic | null {
         label: "Found token",
         kind: "code",
         value: match[1],
+        language: "text",
+      },
+    ],
+  };
+}
+
+function parseMissingComma(message: string): ParsedDiagnostic | null {
+  const match = message.match(/^missing ',' in (.+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    family: "missing-comma",
+    title: "Missing comma",
+    summary: "Go expected a comma separator here before the syntax could continue.",
+    rawMessage: message,
+    details: [
+      {
+        label: "Context",
+        kind: "text",
+        value: match[1],
+      },
+      {
+        label: "Expected token",
+        kind: "code",
+        value: ",",
         language: "text",
       },
     ],

--- a/packages/formatter/test/formatter.test.ts
+++ b/packages/formatter/test/formatter.test.ts
@@ -118,6 +118,25 @@ describe("parseGoDiagnostic", () => {
     );
   });
 
+  it("formats missing comma diagnostics", () => {
+    const parsed = parseGoDiagnostic("missing ',' in argument list");
+
+    expect(parsed.family).toBe("missing-comma");
+    expect(parsed.title).toBe("Missing comma");
+    expect(parsed.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Context",
+          value: "argument list",
+        }),
+        expect.objectContaining({
+          label: "Expected token",
+          value: ",",
+        }),
+      ])
+    );
+  });
+
   it("falls back for unmatched diagnostics", () => {
     const parsed = parseGoDiagnostic("made up diagnostic");
     expect(parsed.family).toBe("fallback");

--- a/packages/vscode-formatter/test/vscode-formatter.test.ts
+++ b/packages/vscode-formatter/test/vscode-formatter.test.ts
@@ -82,6 +82,19 @@ describe("prettifyDiagnosticForHover", () => {
     expect(markdown).toContain("```text\n'{'\n```");
   });
 
+  it("renders missing comma diagnostics", () => {
+    const markdown = prettifyDiagnosticForHover({
+      source: "syntax",
+      message: "missing ',' in argument list",
+    });
+
+    expect(markdown).toContain("### Missing comma");
+    expect(markdown).toContain("Source: syntax");
+    expect(markdown).toContain("- **Context:** argument list");
+    expect(markdown).toContain("**Expected token**");
+    expect(markdown).toContain("```text\n,\n```");
+  });
+
   it("falls back cleanly when a partially similar diagnostic does not match a rule", () => {
     const markdown = prettifyDiagnosticForHover({
       message: "cannot use value with an unexpected diagnostic layout",


### PR DESCRIPTION
This PR adds support for another (1) golang diagnostic (missing comma in argument list) but is also needed to include PR for pre-release-v5.5 which desynced from published VSIX (0.5.5 had two pushes and cannot override in marketplace under same package name)

So, this PR satisfies bumping to v0.5.6 with a new diag support + the 2x piggy backed from 0.5.5.2