### PR TITLE
Release v0.6.3

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Pretty Go Errors",
   "publisher": "CWDev",
   "description": "Make Go diagnostics easier to read in VS Code hovers",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/colinwilliams91/pretty-go-errors",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/vscode-extension": {
       "name": "pretty-go-errors",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pretty-go-errors/vscode-formatter": "*"

--- a/packages/formatter/src/prettifyGoDiagnostic.ts
+++ b/packages/formatter/src/prettifyGoDiagnostic.ts
@@ -109,7 +109,7 @@ function parseCallArgumentCount(message: string): ParsedDiagnostic | null {
 
 function parseCannotUse(message: string): ParsedDiagnostic | null {
   const withContext = message.match(
-    /^cannot use (.+?) \(value of type (.+?)\) as (.+?) value in (.+?)(?:: ([\s\S]+))?$/
+    /^cannot use (.+?) \((?:value|variable|constant) of type (.+?)\) as (.+?) value in (.+?)(?:: ([\s\S]+))?$/
   );
   if (withContext) {
     const [, value, actualType, expectedType, context, reason] = withContext;
@@ -124,7 +124,7 @@ function parseCannotUse(message: string): ParsedDiagnostic | null {
   }
 
   const generic = message.match(
-    /^cannot use (.+?) \(value of type (.+?)\) as (.+?)(?:: ([\s\S]+))?$/
+    /^cannot use (.+?) \((?:value|variable|constant) of type (.+?)\) as (.+?)(?:: ([\s\S]+))?$/
   );
   if (!generic) {
     return null;

--- a/packages/formatter/test/formatter.test.ts
+++ b/packages/formatter/test/formatter.test.ts
@@ -21,6 +21,57 @@ describe("parseGoDiagnostic", () => {
     );
   });
 
+  it("formats cannot use diagnostics with a variable of type phrase", () => {
+    const parsed = parseGoDiagnostic(
+      "cannot use v.Middle.Inner.Value (variable of type int) as string value in assignment"
+    );
+
+    expect(parsed.family).toBe("cannot-use");
+    expect(parsed.title).toBe("Type mismatch");
+    expect(parsed.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Value",
+          value: "v.Middle.Inner.Value",
+        }),
+        expect.objectContaining({ label: "Actual type", value: "int" }),
+        expect.objectContaining({
+          label: "Expected type",
+          value: "string",
+        }),
+        expect.objectContaining({
+          label: "Context",
+          value: "assignment",
+        }),
+      ])
+    );
+  });
+
+  it("formats cannot use diagnostics with a constant of type phrase", () => {
+    const parsed = parseGoDiagnostic(
+      "cannot use untyped constant (constant of type int) as string value in assignment"
+    );
+
+    expect(parsed.family).toBe("cannot-use");
+    expect(parsed.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Value",
+          value: "untyped constant",
+        }),
+        expect.objectContaining({ label: "Actual type", value: "int" }),
+        expect.objectContaining({
+          label: "Expected type",
+          value: "string",
+        }),
+        expect.objectContaining({
+          label: "Context",
+          value: "assignment",
+        }),
+      ])
+    );
+  });
+
   it("formats undefined diagnostics", () => {
     const parsed = parseGoDiagnostic("undefined: fmt.Prinln");
     expect(parsed.family).toBe("undefined");

--- a/packages/vscode-formatter/test/vscode-formatter.test.ts
+++ b/packages/vscode-formatter/test/vscode-formatter.test.ts
@@ -199,6 +199,27 @@ describe("prettifyDiagnosticForHover", () => {
     expect(markdown).toContain("**Original diagnostic**");
   });
 
+  it("renders cannot use diagnostics that use the 'variable of type' phrasing", () => {
+    const markdown = prettifyDiagnosticForHover({
+      source: "compiler",
+      code: "IncompatibleAssign",
+      message:
+        "cannot use v.Middle.Inner.Value (variable of type int) as string value in assignment",
+    });
+
+    expect(markdown).toContain("### Type mismatch");
+    expect(markdown).toContain("Source: compiler");
+    expect(markdown).toContain("**Value**");
+    // Long dotted selector has no fluent `).` boundaries, so it stays on one line.
+    expect(markdown).toContain("```go\nv.Middle.Inner.Value\n```");
+    expect(markdown).toContain("**Actual type**");
+    expect(markdown).toContain("```go\nint\n```");
+    expect(markdown).toContain("**Expected type**");
+    expect(markdown).toContain("```go\nstring\n```");
+    expect(markdown).toContain("**Context:** assignment");
+    expect(markdown).toContain("**Original diagnostic**");
+  });
+
   it("falls back cleanly when a partially similar diagnostic does not match a rule", () => {
     const markdown = prettifyDiagnosticForHover({
       message: "cannot use value with an unexpected diagnostic layout",


### PR DESCRIPTION
relax regex for praseCannotUse mismatch family 2.5x-3x coverage